### PR TITLE
rid-macro: normalized `#allow` pragma across rendered tokens

### DIFF
--- a/rid-macro-impl/src/accesses/render_collection_accesses.rs
+++ b/rid-macro-impl/src/accesses/render_collection_accesses.rs
@@ -6,7 +6,7 @@ use quote::{format_ident, quote, quote_spanned};
 use crate::{
     attrs::TypeInfoMap,
     common::state::{get_state, ImplementationType},
-    render_rust::ffi_prelude,
+    render_rust::{allow_prelude, ffi_prelude},
 };
 
 use super::{
@@ -210,7 +210,9 @@ fn aggregate_collection_accesses(
                     // We need to wrap this in these in a module in case the nested accesses
                     // result in rendering the same typedefs.
                     let mod_ident = format_ident!("mod_{}_access", x.key());
+                    let allow = allow_prelude();
                     let rust = quote_spanned! { x.span() =>
+                        #allow
                         mod #mod_ident {
                             use super::*;
                             #(#typedef_tokens)*

--- a/rid-macro-impl/src/display/display_test.rs
+++ b/rid-macro-impl/src/display/display_test.rs
@@ -1,4 +1,5 @@
 use super::{rid_display_impl, DisplayImplConfig};
+use crate::render_rust::allow_prelude;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;
@@ -11,6 +12,7 @@ fn render(input: proc_macro2::TokenStream) -> TokenStream {
 // TODO: we aren't testing the generated dart code
 // TODO: we should not render the #[no_mangle]... preamble during tests
 mod enums_display_impl {
+
     use super::*;
 
     #[test]
@@ -21,11 +23,12 @@ mod enums_display_impl {
             }
         });
 
+        let allow = allow_prelude();
         let expected = quote! {
             mod __rid_mod_rid_single_display {
                 use super::*;
                 #[no_mangle]
-                #[allow(non_snake_case)]
+                #allow
                 pub extern "C" fn rid_single_display(n: i32) -> *const ::std::os::raw::c_char {
                     let instance = match n {
                         0 => Single::First,
@@ -51,11 +54,12 @@ mod enums_display_impl {
             }
         });
 
+        let allow = allow_prelude();
         let expected = quote! {
             mod __rid_mod_rid_single_display {
                 use super::*;
                 #[no_mangle]
-                #[allow(non_snake_case)]
+                #allow
                 pub extern "C" fn rid_single_display(n: i32) -> *const ::std::os::raw::c_char {
                     let instance = match n {
                         0 => Single::First,
@@ -85,11 +89,12 @@ mod structs_display_impl {
             struct Single { id: u32 }
         });
 
+        let allow = allow_prelude();
         let expected = quote! {
             mod __rid_mod_rid_single_display {
                 use super::*;
                 #[no_mangle]
-                #[allow(non_snake_case)]
+                #allow
                 pub extern "C" fn rid_single_display(ptr: *mut Single) -> *const ::std::os::raw::c_char {
                     let instance = unsafe {
                         assert!(!ptr.is_null());

--- a/rid-macro-impl/src/export/attach.rs
+++ b/rid-macro-impl/src/export/attach.rs
@@ -10,7 +10,9 @@ use crate::{
     parse::{ParsedFunction, ParsedImplBlock},
     render_common::{PointerTypeAlias, RenderFunctionExportConfig},
     render_dart,
-    render_rust::{self, ffi_prelude, render_free, RenderedTypeAliasInfo},
+    render_rust::{
+        allow_prelude, ffi_prelude, render_free, RenderedTypeAliasInfo,
+    },
 };
 
 use super::{
@@ -83,8 +85,9 @@ pub fn rid_export_impl(
                 TokenStream::new()
             };
 
+            let allow = allow_prelude();
             quote! {
-                #[allow(non_snake_case)]
+                #allow
                 mod #module_ident {
                     use super::*;
                     #(#ptr_typedef_tokens)*
@@ -141,8 +144,9 @@ pub fn rid_export_impl(
             let module_ident =
                 format_ident!("__rid_export_{}", parsed_fn.fn_ident);
 
+            let allow = allow_prelude();
             quote_spanned! { parsed_fn.fn_ident.span() =>
-                #[allow(non_snake_case)]
+                #allow
                 mod #module_ident {
                     use super::*;
                     #(#ptr_typedef_tokens)*

--- a/rid-macro-impl/src/export/export_test.rs
+++ b/rid-macro-impl/src/export/export_test.rs
@@ -3,6 +3,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use super::export_config::ExportConfig;
+use crate::render_rust::allow_prelude;
 
 // -----------------
 // Note these are just a few high level integration tests to see that all comes together.
@@ -27,7 +28,7 @@ fn render_export_full(input: TokenStream) -> TokenStream {
 // Struct impl methods
 // -----------------
 mod struct_impl_methods {
-    use crate::common::dump_tokens;
+    use crate::{common::dump_tokens, render_rust::allow_prelude};
 
     use super::*;
 
@@ -50,8 +51,9 @@ mod struct_impl_methods {
             }
         };
 
+        let allow = allow_prelude();
         let expected = quote! {
-            #[allow(non_snake_case)]
+            #allow
             mod __rid_MyStruct_impl_1 {
                 use super::*;
                 type PointerMut_Self = *mut Self;
@@ -81,8 +83,9 @@ mod struct_impl_methods {
             }
         };
 
+        let allow = allow_prelude();
         let expected = quote! {
-            #[allow(non_snake_case)]
+            #allow
             mod __rid_MyStruct_impl_1 {
                 use super::*;
                 fn rid_export_MyStruct_get_u8s() -> rid::RidVec<u8> {
@@ -99,7 +102,7 @@ mod struct_impl_methods {
     }
 }
 mod struct_impl_args_methods {
-    use crate::common::dump_tokens;
+    use crate::{common::dump_tokens, render_rust::allow_prelude};
 
     use super::*;
 
@@ -119,8 +122,9 @@ mod struct_impl_args_methods {
             }
         };
 
+        let allow = allow_prelude();
         let expected = quote! {
-            #[allow(non_snake_case)]
+            #allow
             mod __rid_MyStruct_impl_1 {
                 use super::*;
                 fn rid_export_MyStruct_get_keys(arg0: *const HashMap<u8, u8>) -> rid::RidVec<u8> {
@@ -152,8 +156,9 @@ mod functions_no_args {
             fn get_u8() -> u8 { 1 }
         };
 
+        let allow = allow_prelude();
         let expected = quote! {
-            #[allow(non_snake_case)]
+            #allow
             mod __rid_export_get_u8 {
                 use super::*;
                 fn rid_export_get_u8() -> u8 {
@@ -187,8 +192,9 @@ mod functions_with_args {
             }
         };
 
+        let allow = allow_prelude();
         let expected = quote! {
-            #[allow(non_snake_case)]
+            #allow
             mod __rid_export_get_keys {
                 use super::*;
                 fn rid_export_get_keys(arg0: *const HashMap<u8, u8>) -> rid::RidVec<u8> {

--- a/rid-macro-impl/src/model/debug/debug_test.rs
+++ b/rid-macro-impl/src/model/debug/debug_test.rs
@@ -1,4 +1,7 @@
-use crate::{common::extract_variant_names, parse::rust_type::RustType};
+use crate::{
+    common::extract_variant_names, parse::rust_type::RustType,
+    render_rust::allow_prelude,
+};
 
 use super::{render_debug, RenderDebugConfig};
 use proc_macro2::TokenStream;
@@ -34,6 +37,8 @@ fn render(input: proc_macro2::TokenStream) -> TokenStream {
 }
 
 mod enums_debug_impl {
+    use crate::render_rust::allow_prelude;
+
     use super::*;
 
     #[test]
@@ -44,11 +49,12 @@ mod enums_debug_impl {
             }
         });
 
+        let allow = allow_prelude();
         let expected = quote! {
             mod __rid_mod_rid_single_debug {
                 use super::*;
                 #[no_mangle]
-                #[allow(non_snake_case)]
+                #allow
                 pub extern "C" fn rid_single_debug(n: i32) -> *const ::std::os::raw::c_char {
                     let instance = match n {
                         0 => Single::First,
@@ -59,7 +65,7 @@ mod enums_debug_impl {
                     cstring.into_raw()
                 }
                 #[no_mangle]
-                #[allow(non_snake_case)]
+                #allow
                 pub extern "C" fn rid_single_debug_pretty(n: i32) -> *const ::std::os::raw::c_char {
                     let instance = match n {
                         0 => Single::First,
@@ -77,6 +83,7 @@ mod enums_debug_impl {
 }
 
 mod structs_debug_impl {
+
     use super::*;
 
     #[test]
@@ -85,11 +92,12 @@ mod structs_debug_impl {
             struct Single { id: u32 }
         });
 
+        let allow = allow_prelude();
         let expected = quote! {
             mod __rid_mod_rid_single_debug {
                 use super::*;
                 #[no_mangle]
-                #[allow(non_snake_case)]
+                #allow
                 pub extern "C" fn rid_single_debug(ptr: *mut Single) -> *const ::std::os::raw::c_char {
                     let single = unsafe {
                         assert!(!ptr.is_null());
@@ -101,7 +109,7 @@ mod structs_debug_impl {
                     cstring.into_raw()
                 }
                 #[no_mangle]
-                #[allow(non_snake_case)]
+                #allow
                 pub extern "C" fn rid_single_debug_pretty(ptr: *mut Single) -> *const ::std::os::raw::c_char {
                     let single = unsafe {
                         assert!(!ptr.is_null());

--- a/rid-macro-impl/src/model/field_access/render_field_access_test.rs
+++ b/rid-macro-impl/src/model/field_access/render_field_access_test.rs
@@ -3,6 +3,7 @@ use crate::{
     attrs::StructConfig,
     common::state::get_state,
     parse::ParsedStruct,
+    render_rust::allow_prelude,
     rid_export_impl,
 };
 use proc_macro2::TokenStream;
@@ -433,9 +434,11 @@ mod struct_field_access_single_vec_custom_struct {
             }
         };
 
+        let allow = allow_prelude();
         let expected = quote! {
             mod __my_struct_field_access {
                 use super::*;
+                #allow
                 mod mod_vec_todo_access {
                     use super::*;
                     fn rid_len_vec_todo(ptr: *mut Vec<Todo>) -> usize {
@@ -512,9 +515,11 @@ mod struct_field_access_single_vec_u8 {
             }
         };
 
+        let allow = allow_prelude();
         let expected = quote! {
             mod __my_struct_field_access {
                 use super::*;
+                #allow
                 mod mod_vec_u8_access {
                     use super::*;
                     fn rid_len_vec_u8(ptr: *mut Vec<u8>) -> usize {

--- a/rid-macro-impl/src/model/store/store_field_wrappers.rs
+++ b/rid-macro-impl/src/model/store/store_field_wrappers.rs
@@ -7,6 +7,7 @@ use crate::{
     attrs::TypeInfoMap,
     parse::{ParsedStruct, ParsedStructField},
     render_dart::RenderDartTypeOpts,
+    render_rust::allow_prelude,
 };
 
 /// Renders wrapper accessors for all fields on a given raw Pointer type, i.e. `RawStore`.
@@ -45,8 +46,9 @@ impl ParsedStruct {
 
         let mod_ident = format_ident!("{}_field_wrappers", self.ident);
         let fn_ident = format_ident!("_include_{}_field_wrappers", self.ident);
+        let allow = allow_prelude();
         quote_spanned! { self.ident.span() =>
-            #[allow(non_snake_case)]
+            #allow
             mod #mod_ident {
                 #field_wrapper_tokens
                 #[no_mangle]

--- a/rid-macro-impl/src/model/to_dart/to_dart.rs
+++ b/rid-macro-impl/src/model/to_dart/to_dart.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     parse::{rust_type::RustType, ParsedStruct},
     render_dart::ParsedStructRenderConfig,
-    render_rust::RenderedDisplayImpl,
+    render_rust::{allow_prelude, RenderedDisplayImpl},
 };
 
 pub struct DartRenderImplConfig {
@@ -91,8 +91,9 @@ pub fn render_to_dart(
     let ident = &parsed_struct.ident;
     let mod_ident = format_ident!("__rid_{}_dart_mod", ident);
     let fn_ident = format_ident!("_to_dart_for_{}", ident);
+    let allow = allow_prelude();
     quote_spanned! { ident.span() =>
-        #[allow(non_snake_case)]
+        #allow
         mod #mod_ident {
             #dart_tokens
             #[no_mangle]

--- a/rid-macro-impl/src/render_rust/ffi_prelude.rs
+++ b/rid-macro-impl/src/render_rust/ffi_prelude.rs
@@ -1,10 +1,15 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
+pub fn allow_prelude() -> TokenStream {
+    quote! { #[allow(non_snake_case, non_camel_case_types, unused_imports)] }
+}
+
 pub fn ffi_prelude() -> TokenStream {
+    let allow = allow_prelude();
     quote! {
         #[no_mangle]
-        #[allow(non_snake_case)]
+        #allow
         pub extern "C"
     }
 }

--- a/rid-macro-impl/src/render_rust/mod.rs
+++ b/rid-macro-impl/src/render_rust/mod.rs
@@ -1,4 +1,4 @@
-pub use ffi_prelude::ffi_prelude;
+pub use ffi_prelude::*;
 pub use render_access_item::*;
 pub use render_debug_impl::*;
 pub use render_display_impl::*;

--- a/rid-macro-impl/src/render_rust/render_debug_impl.rs
+++ b/rid-macro-impl/src/render_rust/render_debug_impl.rs
@@ -12,6 +12,7 @@ use crate::{
         },
     },
     parse::rust_type::{Composite, RustType, TypeKind, Value},
+    render_rust::allow_prelude,
 };
 
 pub struct RenderedDebugImpl {
@@ -95,9 +96,10 @@ impl RustType {
         // TODO: consider using type aliases over `*mut` types via `self.render_pointer_type()`
         let resolve_struct_ptr = resolve_ptr(struct_ident);
 
+        let allow = allow_prelude();
         let tokens = quote_spanned! { struct_ident.span() =>
             #[no_mangle]
-            #[allow(non_snake_case)]
+            #allow
             pub extern "C" fn #fn_debug_method_ident(ptr: *mut #struct_ident) -> *const ::std::os::raw::c_char {
                 let #struct_instance_ident = #resolve_struct_ptr;
                 let s = format!("{:?}", #struct_instance_ident);
@@ -105,7 +107,7 @@ impl RustType {
                 cstring.into_raw()
             }
             #[no_mangle]
-            #[allow(non_snake_case)]
+            #allow
             pub extern "C" fn #fn_debug_pretty_method_ident(ptr: *mut #struct_ident) -> *const ::std::os::raw::c_char {
                 let #struct_instance_ident = #resolve_struct_ptr;
                 let s = format!("{:#?}", #struct_instance_ident);
@@ -130,6 +132,7 @@ impl RustType {
             self.get_fn_debug_idents();
         let enum_ident = &self.rust_ident();
 
+        let allow = allow_prelude();
         let tokens = if is_primitive {
             // NOTE: assuming `repr(C)` for primitive enums
             let ResolvedEnumFromInt {
@@ -141,7 +144,7 @@ impl RustType {
 
             quote_spanned! { enum_ident.span() =>
                 #[no_mangle]
-                #[allow(non_snake_case)]
+                #allow
                 pub extern "C" fn #fn_debug_method_ident(#arg_ident: #arg_type_ident) -> *const ::std::os::raw::c_char {
                     #resolve_enum_arg_tokens
                     let s = format!("{:?}", #instance_ident);
@@ -149,7 +152,7 @@ impl RustType {
                     cstring.into_raw()
                 }
                 #[no_mangle]
-                #[allow(non_snake_case)]
+                #allow
                 pub extern "C" fn #fn_debug_pretty_method_ident(#arg_ident: #arg_type_ident) -> *const ::std::os::raw::c_char {
                     #resolve_enum_arg_tokens
                     let s = format!("{:#?}", #instance_ident);
@@ -161,7 +164,7 @@ impl RustType {
             let resolve_enum_ptr = resolve_ptr(enum_ident);
             quote_spanned! { enum_ident.span() =>
                 #[no_mangle]
-                #[allow(non_snake_case)]
+                #allow
                 pub extern "C" fn #fn_debug_method_ident(ptr: *mut #enum_ident) -> *const ::std::os::raw::c_char {
                     let instance = #resolve_enum_ptr;
                     let s = format!("{:?}", instance);
@@ -169,7 +172,7 @@ impl RustType {
                     cstring.into_raw()
                 }
                 #[no_mangle]
-                #[allow(non_snake_case)]
+                #allow
                 pub extern "C" fn #fn_debug_pretty_method_ident(ptr: *mut #enum_ident) -> *const ::std::os::raw::c_char {
                     let instance = #resolve_enum_ptr;
                     let s = format!("{:#?}", instance);

--- a/tests/dart/field_access/Makefile
+++ b/tests/dart/field_access/Makefile
@@ -12,7 +12,7 @@ test: ./.dart_tool/
 	dart run test ./test/$(TEST).dart
 
 expand:
-	cargo expand --example $(TEST) 
+	@cargo expand --example $(TEST) 
 
 ./.dart_tool/:
 	pub get


### PR DESCRIPTION
- adding it to rendered access modules fixed warnings
- more warnings were fixed since normalized allow pragma includes
  ignores more warnings
