### PR TITLE
rid-macro: adding ability to skip a struct field

### DIFF
--- a/rid-macro-impl/src/attrs/config_enum.rs
+++ b/rid-macro-impl/src/attrs/config_enum.rs
@@ -43,6 +43,12 @@ impl EnumConfig {
                         "cannot have rid::export attribute on enums"
                     );
                 }
+                RidAttr::Rid(attr_ident, _) => {
+                    abort!(
+                        attr_ident,
+                        "cannot have rid() config attributes on enums"
+                    );
+                }
                 RidAttr::DeriveDebug(_) => debug = true,
             }
         }

--- a/rid-macro-impl/src/attrs/config_function.rs
+++ b/rid-macro-impl/src/attrs/config_function.rs
@@ -46,6 +46,12 @@ impl FunctionConfig {
                     is_exported = true;
                     fn_export_alias = name.clone();
                 }
+                RidAttr::Rid(attr_ident, _) => {
+                    abort!(
+                        attr_ident,
+                        "cannot have config rid() attributes on function exports"
+                    );
+                }
                 // The below are invalid on a function but already checked by Rust itself
                 RidAttr::DeriveDebug(_) => {}
             }

--- a/rid-macro-impl/src/attrs/config_impl_block.rs
+++ b/rid-macro-impl/src/attrs/config_impl_block.rs
@@ -42,6 +42,12 @@ impl ImplBlockConfig {
                         is_exported = true;
                     }
                 }
+                RidAttr::Rid(attr_ident, _) => {
+                    abort!(
+                        attr_ident,
+                        "cannot have config rid() attributes on impl blocks"
+                    );
+                }
                 // The below are invalid on an impl block but already checked by Rust itself
                 RidAttr::DeriveDebug(_) => {}
             }

--- a/rid-macro-impl/src/attrs/config_struct.rs
+++ b/rid-macro-impl/src/attrs/config_struct.rs
@@ -42,6 +42,12 @@ impl StructConfig {
                         "cannot have rid::export attribute on structs"
                     );
                 }
+                RidAttr::Rid(attr_ident, _) => {
+                    abort!(
+                        attr_ident,
+                        "cannot have config rid() attributes on structs only on its fields"
+                    );
+                }
                 RidAttr::DeriveDebug(_) => debug = true,
             }
         }

--- a/rid-macro-impl/src/message/config_message_enum.rs
+++ b/rid-macro-impl/src/message/config_message_enum.rs
@@ -47,6 +47,12 @@ impl MessageEnumConfig {
                         "cannot have rid::export attribute on enums"
                     );
                 }
+                RidAttr::Rid(attr_ident, _) => {
+                    abort!(
+                        attr_ident,
+                        "cannot have config rid() attributes on message enum"
+                    );
+                }
                 RidAttr::DeriveDebug(_) => debug = true,
             }
         }

--- a/rid-macro-impl/src/model/field_access/render_field_access.rs
+++ b/rid-macro-impl/src/model/field_access/render_field_access.rs
@@ -22,6 +22,10 @@ impl ParsedStruct {
         rust_config: &RenderRustAccessConfig,
         dart_config: &RenderDartAccessConfig,
     ) -> (TokenStream, String) {
+        if self.fields.is_empty() {
+            return (TokenStream::new(), String::new());
+        }
+
         let RenderRustFieldAccessResult {
             tokens: rust_tokens,
             collection_accesses,

--- a/rid-macro/src/lib.rs
+++ b/rid-macro/src/lib.rs
@@ -127,6 +127,15 @@ pub fn enums(_attrs: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 // -----------------
+// #[derive(rid::Config)]
+// -----------------
+#[proc_macro_derive(Config, attributes(rid))]
+#[proc_macro_error]
+pub fn rid_attr(_input: TokenStream) -> TokenStream {
+    TokenStream::new()
+}
+
+// -----------------
 // #[derive(rid::Display)]
 // -----------------
 #[proc_macro_derive(Display)]


### PR DESCRIPTION
- introduced `#[derive(rid::Config)]` which adds rid config attributes
  to the model struct it is applied to
- `#[derive(rid::Config)]` itself does not add any generated code, but
  just serves to introduce the attrs
- those attrs are used to configure each struct field if needed, so far
  `#[rid(skip)]` to omit it from rendering FFI wrapper code
- attr syntax modeled after
  [serde(skip)](https://serde.rs/field-attrs.html#skip)
- as with serde attrs `rid(*)` are extensible for future needs

NOTE: I tried to opaquely add this `derive` to each model struct, but
caused problems when another proc_macro attribute comes after (derive
attrs need to be last). In the future we could explore rewriting the
TokenStream and inject the derive in the right place so the user doesn't
have to add it explicitly.
