### PR TITLE
feat: rid log/msg improvements

### DIFF
--- a/rid-build/dart/_message_channel.dart
+++ b/rid-build/dart/_message_channel.dart
@@ -6,7 +6,15 @@ import '_isolate_binding.dart' show initIsolate;
 
 const String _MSG_SEPARATOR = '^';
 
-enum RidMessageType { Severe, Error, LogWarn, LogInfo, LogDebug }
+enum RidMessageType {
+  Severe,
+  Error,
+  LogWarn,
+  LogInfo,
+  LogDebug,
+  MsgInfo,
+  MsgWarn
+}
 
 RidMessageType _ridMsgTypeFromString(String s) {
   switch (s.toLowerCase()) {
@@ -20,6 +28,10 @@ RidMessageType _ridMsgTypeFromString(String s) {
       return RidMessageType.LogInfo;
     case "log_debug":
       return RidMessageType.LogDebug;
+    case "msg_warn":
+      return RidMessageType.MsgWarn;
+    case "msg_info":
+      return RidMessageType.MsgInfo;
     default:
       throw ArgumentError.value(s);
   }

--- a/rid-ffi/src/message.rs
+++ b/rid-ffi/src/message.rs
@@ -135,3 +135,30 @@ macro_rules! severe {
         rid::_post_message(format!("err_severe^{:?}^{:?}", $msg, $details));
     }};
 }
+
+// -----------------
+// User Messages
+// -----------------
+#[macro_export]
+macro_rules! msg_warn {
+    ($($arg:tt)*) => {{
+        let res = format!($($arg)*);
+
+        #[cfg(test)]
+        eprintln!("MSGW: {}", res);
+        #[cfg(not(test))]
+        rid::_post_message(format!("msg_warn^{}", res));
+    }}
+}
+
+#[macro_export]
+macro_rules! msg_info {
+    ($($arg:tt)*) => {{
+        let res = format!($($arg)*);
+
+        #[cfg(test)]
+        eprintln!("MSGI: {}", res);
+        #[cfg(not(test))]
+        rid::_post_message(format!("msg_info^{}", res));
+    }}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub use rid_ffi::{
     post, RidVec, _encode_with_id, _encode_without_id, _init_msg_isolate,
     _init_reply_isolate, _option_ref_to_pointer, _post_message,
     allo_isolate as _allo_isolate, error, log_debug, log_info, log_warn,
-    severe,
+    msg_info, msg_warn, severe,
 };
 pub use rid_macro::*;
 


### PR DESCRIPTION
Logging to the console when running rust tests for our app and `[cfg(test)]` is active.

Additionally added two more log/msg types `msg_info` and `msg_warn` which are messages that
aren't errors but should be presented to the user via a snackbar or similar.
