### PR TITLE
fix: running tests single threaded to fix race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include ./Makefile.variable
 test: test_rust test_integration
 
 test_rust:
-	cargo test --all
+	cargo test --all -- --test-threads 1
 
 test_integration:
 	cd $(ROOT)tests/dart/field_access && $(MAKE) test-all && \


### PR DESCRIPTION
This PR forces tests to run sequentially in order to avoid failures due to tests affecting each other via race conditions.