### PR TITLE
feat: macOS build+test action

### DIFF
--- a/.github/workflows/build+test (macos).yml
+++ b/.github/workflows/build+test (macos).yml
@@ -1,0 +1,36 @@
+name: Build+Test (macOS)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test_macos:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [nightly]
+        dart_sdk: [2.14.0-115.0.dev] # ffigen depends on Dart v2.14+  
+
+    steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: ${{ matrix.rust }}
+
+    - name: Install GNU Make
+      run: brew install make
+
+    - uses: dart-lang/setup-dart@v1.2
+      with:
+          sdk: ${{ matrix.dart_sdk }} 
+
+    - uses: actions/checkout@master
+
+    - name: Build and Run Tests
+      run: make test 


### PR DESCRIPTION
This patch adds a build+test action for macOS.

Passing build here: https://github.com/SecondFlight/rid/pull/5