### PR TITLE
Fixed cargo workspace errors when generating a new project.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ exclude = [
   "tests/dart/field_access",
   "tests/dart/apps",
   "tests/dart/export",
-  "tests/dart/framework"
+  "tests/dart/framework",
+  "rid-template-flutter",
 ]
 
 [dependencies]


### PR DESCRIPTION
I've noticed that `cargo` kept throwing errors about the project created from the template not being in the cargo workspace.
By excluding it from the workspace, we get rid of those messages and gain the ability to run `cargo run` (for some reason, it was running `cargo run` on the parent directory `rid-template-flutter` for me).