### PR TITLE
fix: fixed a copy error during template instantiation.

### DIFF
--- a/rid-template-flutter/setup.sh
+++ b/rid-template-flutter/setup.sh
@@ -23,13 +23,15 @@ flutter create --platforms=android,ios,macos,linux,windows --template=plugin $AP
 cd $APP_ROOT/plugin
 rm -rf example test CHANGELOG.md README.md .idea
 
-if [[ $OSTYPE == 'darwin'* ]]; then
-  cp $TEMPLATE_ROOT/flutter/plugin/ios/Classes/SwiftPlugin.swift ios/Classes/SwiftPlugin.swift
-  cp $TEMPLATE_ROOT/flutter/plugin/ios/plugin.podspec ios/plugin.podspec
-  cp $TEMPLATE_ROOT/flutter/plugin/macos/Classes/Plugin.swift macos/Classes/Plugin.swift 
-  cp $TEMPLATE_ROOT/flutter/plugin/macos/plugin.podspec macos/plugin.podspec
-  cp $TEMPLATE_ROOT/flutter/plugin/pubspec.yaml pubspec.yaml
+if [[ $OSTYPE != 'darwin'* ]]; then
+  mkdir -p ios/Classes
+  mkdir -p macos/Classes
 fi
+cp $TEMPLATE_ROOT/flutter/plugin/ios/Classes/SwiftPlugin.swift ios/Classes/SwiftPlugin.swift
+cp $TEMPLATE_ROOT/flutter/plugin/ios/plugin.podspec ios/plugin.podspec
+cp $TEMPLATE_ROOT/flutter/plugin/macos/Classes/Plugin.swift macos/Classes/Plugin.swift 
+cp $TEMPLATE_ROOT/flutter/plugin/macos/plugin.podspec macos/plugin.podspec
+cp $TEMPLATE_ROOT/flutter/plugin/pubspec.yaml pubspec.yaml
 
 flutter pub get
 


### PR DESCRIPTION
I've added `mkdir` command that creates missing folders that would otherwise throw errors during the `setup.sh` template creation.
```
cp: cannot create regular file 'macos/Classes/Plugin.swift': No such file or directory
cp: cannot create regular file 'macos/plugin.podspec': No such file or directory
```

## Notes:
- `-p` creates full path, might not work on macOS (haven't used it before)