### PR TITLE
fix: Added linux_run script for LD_LIBRARY_PATH.

### DIFF
--- a/rid-template-flutter/sh/linux_run
+++ b/rid-template-flutter/sh/linux_run
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+PREV_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+LD_LIBRARY_PATH="$DIR/../plugin/linux"
+
+flutter run -d linux
+
+LD_LIBRARY_PATH=PREV_LD_LIBRARY_PATH


### PR DESCRIPTION
In Linux, there's a problem when `.so` files (dynamic libraries) get copied into `plugin/linux` they're not found when running.

I've added a run script that changes the `LD_LIBRARY_PATH`, which is the path that Linux uses to search for dynamic libraries.

After the execution is completed, the environment variable is reset back to the previous value.

## Usage:
Go into the root of your project and execute `./sh/linux_run`, and it should execute the same way as it does on other platforms when you run `flutter run -d <platform>`.

## Notes:
- I'm not sure this is the best approach, but it's the best I've managed to get working.